### PR TITLE
Fix Warning: Prop `href` did not match

### DIFF
--- a/src/components/LanguageMenu.js
+++ b/src/components/LanguageMenu.js
@@ -19,7 +19,7 @@ const LanguageMenu = (props) => {
 				const path = pathname.replace(/\[lang\]/i, lang);
 
 				return (
-					<Link key={index} prefetch={false} href={path}>
+					<Link key={index} prefetch={false} href={pathname} as={path}>
 						<a className={classes.concat(current).join(' ').trim()}>{i18next.t(lang)}</a>
 					</Link>
 				);

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -28,7 +28,7 @@ const Layout = function ({ children, home }) {
 			<main>{children}</main>
 
 			{!home && (
-				<Link href={'/' + i18next.language}>
+				<Link href={`/[lang]`} as={`/${i18next.language}`}>
 					<a className="text-blue-600">{i18next.t('backTo')} /</a>
 				</Link>
 			)}

--- a/src/pages/[lang]/index.js
+++ b/src/pages/[lang]/index.js
@@ -8,11 +8,11 @@ import { getAllLanguageSlugs, getLanguage } from '../../lib/lang';
 export default function LangIndex({ language }) {
 	return (
 		<Layout>
-			<h1 className="mt-5 mb-5 font-bold text-4xl">index.js</h1>
+			<h1 className="mt-5 mb-5 text-4xl font-bold">index.js</h1>
 			<div>
 				{i18next.t('language')}: {language}
 			</div>
-			<Link prefetch={false} href={language + '/test'}>
+			<Link prefetch={false} href={`/[lang]/test`} as={`/${language}/test`}>
 				<a className="text-blue-600">/{language}/test</a>
 			</Link>
 		</Layout>


### PR DESCRIPTION
Hi @Xairoo, your solution works well, I just added a small fix adapting the Links with the as attribute so that the matching works correctly and prevent the warning:
`react-dom.development.js: 88 Warning: Prop 'href' did not match. Server: "en/test" Client: "/en/test"`